### PR TITLE
Ubports: update source location link

### DIFF
--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
-http://archive.ubuntu.com/ubuntu/pool/main/b/bluez/bluez_5.41.orig.tar.xz
-bluez_5.42+ubports.orig.tar.xz
+http://www.kernel.org/pub/linux/bluetooth/bluez-5.41.tar.xz
+bluez_5.42+ubports1.orig.tar.xz


### PR DESCRIPTION
The old link does not exist anymore.