### PR TITLE
Security fix for CVE-2017-1000250

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,13 @@
+String stashFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo,lintian.txt'
+String archiveFileList = '*.gz,*.bz2,*.xz,*.deb,*.ddeb,*.udeb,*.dsc,*.changes,*.buildinfo'
+
 pipeline {
   agent any
   stages {
     stage('Build source') {
       steps {
         sh '/usr/bin/build-source.sh'
-        stash(name: 'source', includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt')
+        stash(name: 'source', includes: stashFileList)
         cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
       }
     }
@@ -17,7 +20,7 @@ pipeline {
               unstash 'source'
               sh '''export architecture="armhf"
 build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-armhf')
+              stash(includes: stashFileList, name: 'build-armhf')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
 
@@ -29,7 +32,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="arm64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-arm64')
+              stash(includes: stashFileList, name: 'build-arm64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           },
@@ -39,7 +42,7 @@ build-binary.sh'''
               unstash 'source'
               sh '''export architecture="amd64"
     build-binary.sh'''
-              stash(includes: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo,lintian.txt', name: 'build-amd64')
+              stash(includes: stashFileList, name: 'build-amd64')
               cleanWs(cleanWhenAborted: true, cleanWhenFailure: true, cleanWhenNotBuilt: true, cleanWhenSuccess: true, cleanWhenUnstable: true, deleteDirs: true)
             }
           }
@@ -52,7 +55,7 @@ build-binary.sh'''
         unstash 'build-armhf'
         unstash 'build-arm64'
         unstash 'build-amd64'
-        archiveArtifacts(artifacts: '*.gz,*.bz2,*.xz,*.deb,*.dsc,*.changes,*.buildinfo', fingerprint: true, onlyIfSuccessful: true)
+        archiveArtifacts(artifacts: archiveFileList, fingerprint: true, onlyIfSuccessful: true)
         sh '''/usr/bin/build-repo.sh'''
       }
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+bluez (5.42+ubports2) xenial; urgency=medium
+
+  * SECURITY UPDATE: information disclosure in service discovery
+    protocol daemon.
+    - debian/patches/CVE-2017-1000250.patch: validate continuation
+      request size before sending response.
+    - CVE-2017-1000250
+    - This patch is copied from bluez version 5.37-0ubuntu5.1 in
+      Ubuntu xenial-security.
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Fri, 28 Feb 2020 16:47:30 +0700
+
 bluez (5.42+ubports1) xenial; urgency=medium
 
   * No change rebuild to publish sources to ubports repo

--- a/debian/patches/CVE-2017-1000250.patch
+++ b/debian/patches/CVE-2017-1000250.patch
@@ -1,0 +1,41 @@
+Description: validate continuation requested data size
+Origin: Armis Security <security@armis.com>
+
+CVE-2017-1000250
+
+Included is our offered patch for the information leak vulnerability:
+
+diff --git a/src/sdpd-request.c b/src/sdpd-request.c
+index 1eefdce..ddeea7f 100644
+--- a/src/sdpd-request.c
++++ b/src/sdpd-request.c
+@@ -918,15 +918,20 @@ static int service_search_attr_req(sdp_req_t *req, sdp_buf_t *buf)
+ 		/* continuation State exists -> get from cache */
+ 		sdp_buf_t *pCache = sdp_get_cached_rsp(cstate);
+ 		if (pCache) {
+-			uint16_t sent = MIN(max, pCache->data_size - cstate->cStateValue.maxBytesSent);
+-			pResponse = pCache->data;
+-			memcpy(buf->data, pResponse + cstate->cStateValue.maxBytesSent, sent);
+-			buf->data_size += sent;
+-			cstate->cStateValue.maxBytesSent += sent;
+-			if (cstate->cStateValue.maxBytesSent == pCache->data_size)
+-				cstate_size = sdp_set_cstate_pdu(buf, NULL);
+-			else
+-				cstate_size = sdp_set_cstate_pdu(buf, cstate);
++			if (cstate->cStateValue.maxBytesSent >= pCache->data_size) {
++				status = SDP_INVALID_CSTATE;
++				SDPDBG("Got bad cstate with invalid size");
++			} else {
++				uint16_t sent = MIN(max, pCache->data_size - cstate->cStateValue.maxBytesSent);
++				pResponse = pCache->data;
++				memcpy(buf->data, pResponse + cstate->cStateValue.maxBytesSent, sent);
++				buf->data_size += sent;
++				cstate->cStateValue.maxBytesSent += sent;
++				if (cstate->cStateValue.maxBytesSent == pCache->data_size)
++					cstate_size = sdp_set_cstate_pdu(buf, NULL);
++				else
++					cstate_size = sdp_set_cstate_pdu(buf, cstate);
++			}
+ 		} else {
+ 			status = SDP_INVALID_CSTATE;
+ 			SDPDBG("Non-null continuation state, but null cache buffer");

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -14,3 +14,6 @@ migrate_scripts_python3.patch
 # dropped with one of the next releases
 0003-tools-mpris-proxy-allow-user-to-specify-different-mp.patch
 0004-obexd-enable-ebook-backend-conditionally.patch
+
+# Secirity fix(es)
+CVE-2017-1000250.patch

--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
 http://www.kernel.org/pub/linux/bluetooth/bluez-5.41.tar.xz
-bluez_5.42+ubports1.orig.tar.xz
+bluez_5.42+ubports2.orig.tar.xz


### PR DESCRIPTION
* SECURITY UPDATE: information disclosure in service discovery
  protocol daemon.
  - debian/patches/CVE-2017-1000250.patch: validate continuation
    request size before sending response.
  - CVE-2017-1000250
  - This patch is copied from bluez version 5.37-0ubuntu5.1 in
    Ubuntu xenial-security.

This PR comes with a Jenkinsfile update.

I would like this PR to be included in OTA-12. This is a security-only fix which adds additional validation, thus the regression potential is low.