### PR TITLE
Import security fixes from 5.37-0ubuntu5.3 in Ubuntu Xenial

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,29 @@
+bluez (5.42+ubports4) xenial; urgency=medium
+
+  * SECURITY UPDATE: buffer overflow in parse_line function
+    - debian/patches/CVE-2016-7837.patch: make sure we don't write past the
+      end of the array in tools/csr.c.
+    - CVE-2016-7837
+    - The patch is copied from version 5.37-0ubuntu5.3 in Ubuntu Xenial.
+      Note that our Bluez version is 5.41 despite the version number 5.42.
+  * SECURITY UPDATE: privilege escalation via improper access control
+    - debian/patches/CVE-2020-0556-pre1.patch: use .accept and .disconnect
+      instead of attio in profiles/input/hog.c, src/device.c, src/device.h.
+    - debian/patches/CVE-2020-0556-1.patch: HOGP must only accept data from
+      bonded devices in profiles/input/hog.c.
+    - debian/patches/CVE-2020-0556-2.patch: HID accepts bonded device
+      connections only in profiles/input/device.c, profiles/input/device.h,
+      profiles/input/input.conf, profiles/input/manager.c.
+    - debian/patches/CVE-2020-0556-3.patch: attempt to set security level
+      if not bonded in profiles/input/hog.c.
+    - debian/patches/CVE-2020-0556-4.patch: add LEAutoSecurity setting to
+      input.conf in profiles/input/device.h, profiles/input/hog.c,
+      profiles/input/input.conf, profiles/input/manager.c.
+    - CVE-2020-0556
+    - The patch is copied from version 5.37-0ubuntu5.3 in Ubuntu Xenial.
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Thu, 16 Apr 2020 20:39:21 +0700
+
 bluez (5.42+ubports3) xenial; urgency=medium
 
   * Make firmware loading directory editable for bcm43xx

--- a/debian/patches/CVE-2016-7837.patch
+++ b/debian/patches/CVE-2016-7837.patch
@@ -1,0 +1,26 @@
+From 8514068150759c1d6a46d4605d2351babfde1601 Mon Sep 17 00:00:00 2001
+From: Johan Hedberg <johan.hedberg@intel.com>
+Date: Wed, 7 Sep 2016 08:45:12 +0300
+Subject: tools/csr: Fix possible buffer overflow
+
+Make sure we don't write past the end of the array.
+---
+ tools/csr.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/csr.c b/tools/csr.c
+index 2c0918909..15ae7c4fb 100644
+--- a/tools/csr.c
++++ b/tools/csr.c
+@@ -2756,7 +2756,7 @@ static int parse_line(char *str)
+ 
+ 	off++;
+ 
+-	while (1) {
++	while (length <= sizeof(array) - 2) {
+ 		value = strtol(off, &end, 16);
+ 		if (value == 0 && off == end)
+ 			break;
+-- 
+cgit 1.2-0.3.lf.el7
+

--- a/debian/patches/CVE-2020-0556-1.patch
+++ b/debian/patches/CVE-2020-0556-1.patch
@@ -1,0 +1,26 @@
+From 8cdbd3b09f29da29374e2f83369df24228da0ad1 Mon Sep 17 00:00:00 2001
+From: Alain Michaud <alainm@chromium.org>
+Date: Tue, 10 Mar 2020 02:35:16 +0000
+Subject: HOGP must only accept data from bonded devices.
+
+HOGP 1.0 Section 6.1 establishes that the HOGP must require bonding.
+
+Reference:
+https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00352.htm
+---
+ profiles/input/hog.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+--- a/profiles/input/hog.c
++++ b/profiles/input/hog.c
+@@ -185,6 +185,10 @@ static int hog_accept(struct btd_service
+ 	struct btd_device *device = btd_service_get_device(service);
+ 	GAttrib *attrib = btd_device_get_attrib(device);
+ 
++	/* HOGP 1.0 Section 6.1 requires bonding */
++	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device)))
++		return -ECONNREFUSED;
++
+ 	/* TODO: Replace GAttrib with bt_gatt_client */
+ 	bt_hog_attach(dev->hog, attrib);
+ 

--- a/debian/patches/CVE-2020-0556-2.patch
+++ b/debian/patches/CVE-2020-0556-2.patch
@@ -1,0 +1,127 @@
+From 3cccdbab2324086588df4ccf5f892fb3ce1f1787 Mon Sep 17 00:00:00 2001
+From: Alain Michaud <alainm@chromium.org>
+Date: Tue, 10 Mar 2020 02:35:18 +0000
+Subject: HID accepts bonded device connections only.
+
+This change adds a configuration for platforms to choose a more secure
+posture for the HID profile.  While some older mice are known to not
+support pairing or encryption, some platform may choose a more secure
+posture by requiring the device to be bonded  and require the
+connection to be encrypted when bonding is required.
+
+Reference:
+https://www.intel.com/content/www/us/en/security-center/advisory/intel-sa-00352.html
+---
+ profiles/input/device.c   | 23 ++++++++++++++++++++++-
+ profiles/input/device.h   |  1 +
+ profiles/input/input.conf |  8 ++++++++
+ profiles/input/manager.c  | 13 ++++++++++++-
+ 4 files changed, 43 insertions(+), 2 deletions(-)
+
+--- a/profiles/input/device.c
++++ b/profiles/input/device.c
+@@ -91,6 +91,7 @@ struct input_device {
+ 
+ static int idle_timeout = 0;
+ static bool uhid_enabled = false;
++static bool classic_bonded_only = false;
+ 
+ void input_set_idle_timeout(int timeout)
+ {
+@@ -102,6 +103,11 @@ void input_enable_userspace_hid(bool sta
+ 	uhid_enabled = state;
+ }
+ 
++void input_set_classic_bonded_only(bool state)
++{
++	classic_bonded_only = state;
++}
++
+ static void input_device_enter_reconnect_mode(struct input_device *idev);
+ static int connection_disconnect(struct input_device *idev, uint32_t flags);
+ 
+@@ -970,8 +976,18 @@ static int hidp_add_connection(struct in
+ 	if (device_name_known(idev->device))
+ 		device_get_name(idev->device, req->name, sizeof(req->name));
+ 
++	/* Make sure the device is bonded if required */
++	if (classic_bonded_only && !device_is_bonded(idev->device,
++				btd_device_get_bdaddr_type(idev->device))) {
++		error("Rejected connection from !bonded device %s", dst_addr);
++		goto cleanup;
++	}
++
+ 	/* Encryption is mandatory for keyboards */
+-	if (req->subclass & 0x40) {
++	/* Some platforms may choose to require encryption for all devices */
++	/* Note that this only matters for pre 2.1 devices as otherwise the */
++	/* device is encrypted by default by the lower layers */
++	if (classic_bonded_only || req->subclass & 0x40) {
+ 		if (!bt_io_set(idev->intr_io, &gerr,
+ 					BT_IO_OPT_SEC_LEVEL, BT_IO_SEC_MEDIUM,
+ 					BT_IO_OPT_INVALID)) {
+@@ -1199,6 +1215,11 @@ static void input_device_enter_reconnect
+ 	DBG("path=%s reconnect_mode=%s", idev->path,
+ 				reconnect_mode_to_string(idev->reconnect_mode));
+ 
++	/* Make sure the device is bonded if required */
++	if (classic_bonded_only && !device_is_bonded(idev->device,
++				btd_device_get_bdaddr_type(idev->device)))
++		return;
++
+ 	/* Only attempt an auto-reconnect when the device is required to
+ 	 * accept reconnections from the host.
+ 	 */
+--- a/profiles/input/device.h
++++ b/profiles/input/device.h
+@@ -29,6 +29,7 @@ struct input_conn;
+ 
+ void input_set_idle_timeout(int timeout);
+ void input_enable_userspace_hid(bool state);
++void input_set_classic_bonded_only(bool state);
+ 
+ int input_device_register(struct btd_service *service);
+ void input_device_unregister(struct btd_service *service);
+--- a/profiles/input/input.conf
++++ b/profiles/input/input.conf
+@@ -11,3 +11,11 @@
+ # Enable HID protocol handling in userspace input profile
+ # Defaults to false (HIDP handled in HIDP kernel module)
+ #UserspaceHID=true
++
++# Limit HID connections to bonded devices
++# The HID Profile does not specify that devices must be bonded, however some
++# platforms may want to make sure that input connections only come from bonded
++# device connections. Several older mice have been known for not supporting
++# pairing/encryption.
++# Defaults to false to maximize device compatibility.
++#ClassicBondedOnly=true
+--- a/profiles/input/manager.c
++++ b/profiles/input/manager.c
+@@ -96,7 +96,7 @@ static int input_init(void)
+ 	config = load_config_file(CONFIGDIR "/input.conf");
+ 	if (config) {
+ 		int idle_timeout;
+-		gboolean uhid_enabled;
++		gboolean uhid_enabled, classic_bonded_only;
+ 
+ 		idle_timeout = g_key_file_get_integer(config, "General",
+ 							"IdleTimeout", &err);
+@@ -114,6 +114,17 @@ static int input_init(void)
+ 			input_enable_userspace_hid(uhid_enabled);
+ 		} else
+ 			g_clear_error(&err);
++
++		classic_bonded_only = g_key_file_get_boolean(config, "General",
++						"ClassicBondedOnly", &err);
++
++		if (!err) {
++			DBG("input.conf: ClassicBondedOnly=%s",
++					classic_bonded_only ? "true" : "false");
++			input_set_classic_bonded_only(classic_bonded_only);
++		} else
++			g_clear_error(&err);
++
+ 	}
+ 
+ 	btd_profile_register(&input_profile);

--- a/debian/patches/CVE-2020-0556-3.patch
+++ b/debian/patches/CVE-2020-0556-3.patch
@@ -1,0 +1,43 @@
+From 35d8d895cd0b724e58129374beb0bb4a2edf9519 Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Tue, 10 Mar 2020 09:59:07 -0700
+Subject: input: hog: Attempt to set security level if not bonded
+
+This attempts to set the security if the device is not bonded, the
+kernel will block any communication on the ATT socket while bumping
+the security and if that fails the device will be disconnected which
+is better than having the device dangling around without being able to
+communicate with it until it is properly bonded.
+---
+ profiles/input/hog.c | 13 +++++++++++--
+ 1 file changed, 11 insertions(+), 2 deletions(-)
+
+--- a/profiles/input/hog.c
++++ b/profiles/input/hog.c
+@@ -49,6 +49,8 @@
+ #include "src/shared/util.h"
+ #include "src/shared/uhid.h"
+ #include "src/shared/queue.h"
++#include "src/shared/att.h"
++#include "src/shared/gatt-client.h"
+ #include "src/plugin.h"
+ 
+ #include "suspend.h"
+@@ -186,8 +188,15 @@ static int hog_accept(struct btd_service
+ 	GAttrib *attrib = btd_device_get_attrib(device);
+ 
+ 	/* HOGP 1.0 Section 6.1 requires bonding */
+-	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device)))
+-		return -ECONNREFUSED;
++	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device))) {
++		struct bt_gatt_client *client;
++
++		client = btd_device_get_gatt_client(device);
++		if (!bt_gatt_client_set_security(client,
++						BT_ATT_SECURITY_MEDIUM)) {
++			return -ECONNREFUSED;
++		}
++	}
+ 
+ 	/* TODO: Replace GAttrib with bt_gatt_client */
+ 	bt_hog_attach(dev->hog, attrib);

--- a/debian/patches/CVE-2020-0556-4.patch
+++ b/debian/patches/CVE-2020-0556-4.patch
@@ -1,0 +1,112 @@
+Backport of:
+
+From f2778f5877d20696d68a452b26e4accb91bfb19e Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Wed, 11 Mar 2020 11:43:21 -0700
+Subject: input: Add LEAutoSecurity setting to input.conf
+
+LEAutoSecurity can be used to enable/disable automatic upgrades of
+security for LE devices, by default it is enabled so existing devices
+that did not require security and were not bonded will automatically
+upgrade the security.
+
+Note: Platforms disabling this setting would require users to manually
+bond the device which may require changes to the user interface to
+always force bonding for input devices as APIs such as Device.Connect
+will no longer work which maybe perceived as a regression.
+---
+ profiles/input/device.h   |  1 +
+ profiles/input/hog.c      | 13 +++++++++++--
+ profiles/input/input.conf |  5 +++++
+ profiles/input/manager.c  | 11 ++++++++++-
+ 4 files changed, 27 insertions(+), 3 deletions(-)
+
+--- a/profiles/input/device.h
++++ b/profiles/input/device.h
+@@ -30,6 +30,7 @@ struct input_conn;
+ void input_set_idle_timeout(int timeout);
+ void input_enable_userspace_hid(bool state);
+ void input_set_classic_bonded_only(bool state);
++void input_set_auto_sec(bool state);
+ 
+ int input_device_register(struct btd_service *service);
+ void input_device_unregister(struct btd_service *service);
+--- a/profiles/input/hog.c
++++ b/profiles/input/hog.c
+@@ -53,6 +53,7 @@
+ #include "src/shared/gatt-client.h"
+ #include "src/plugin.h"
+ 
++#include "device.h"
+ #include "suspend.h"
+ #include "attrib/att.h"
+ #include "attrib/gattrib.h"
+@@ -69,8 +70,14 @@ struct hog_device {
+ };
+ 
+ static gboolean suspend_supported = FALSE;
++static bool auto_sec = true;
+ static struct queue *devices = NULL;
+ 
++void input_set_auto_sec(bool state)
++{
++	auto_sec = state;
++}
++
+ static struct hog_device *hog_device_new(struct btd_device *device,
+ 						struct gatt_primary *prim)
+ {
+@@ -191,11 +198,13 @@ static int hog_accept(struct btd_service
+ 	if (!device_is_bonded(device, btd_device_get_bdaddr_type(device))) {
+ 		struct bt_gatt_client *client;
+ 
++		if (!auto_sec)
++			return -ECONNREFUSED;
++
+ 		client = btd_device_get_gatt_client(device);
+ 		if (!bt_gatt_client_set_security(client,
+-						BT_ATT_SECURITY_MEDIUM)) {
++						BT_ATT_SECURITY_MEDIUM))
+ 			return -ECONNREFUSED;
+-		}
+ 	}
+ 
+ 	/* TODO: Replace GAttrib with bt_gatt_client */
+--- a/profiles/input/input.conf
++++ b/profiles/input/input.conf
+@@ -19,3 +19,8 @@
+ # pairing/encryption.
+ # Defaults to false to maximize device compatibility.
+ #ClassicBondedOnly=true
++
++# LE upgrade security
++# Enables upgrades of security automatically if required.
++# Defaults to true to maximize device compatibility.
++#LEAutoSecurity=true
+--- a/profiles/input/manager.c
++++ b/profiles/input/manager.c
+@@ -96,7 +96,7 @@ static int input_init(void)
+ 	config = load_config_file(CONFIGDIR "/input.conf");
+ 	if (config) {
+ 		int idle_timeout;
+-		gboolean uhid_enabled, classic_bonded_only;
++		gboolean uhid_enabled, classic_bonded_only, auto_sec;
+ 
+ 		idle_timeout = g_key_file_get_integer(config, "General",
+ 							"IdleTimeout", &err);
+@@ -125,6 +125,15 @@ static int input_init(void)
+ 		} else
+ 			g_clear_error(&err);
+ 
++		auto_sec = g_key_file_get_boolean(config, "General",
++						"LEAutoSecurity", &err);
++		if (!err) {
++			DBG("input.conf: LEAutoSecurity=%s",
++					auto_sec ? "true" : "false");
++			input_set_auto_sec(auto_sec);
++		} else
++			g_clear_error(&err);
++
+ 	}
+ 
+ 	btd_profile_register(&input_profile);

--- a/debian/patches/CVE-2020-0556-pre1.patch
+++ b/debian/patches/CVE-2020-0556-pre1.patch
@@ -1,0 +1,131 @@
+From 7d9718cfcc11eaa9d8059e721301cdc00ef8c82e Mon Sep 17 00:00:00 2001
+From: Luiz Augusto von Dentz <luiz.von.dentz@intel.com>
+Date: Mon, 26 Sep 2016 16:44:03 +0300
+Subject: input/hog: Use .accept and .disconnect instead of attio
+
+This adds .accept and .disconnect callbacks instead of attio which
+is deprecated.
+---
+ profiles/input/hog.c | 56 ++++++++++++++++++++++++++--------------------------
+ src/device.c         |  8 ++++++++
+ src/device.h         |  1 +
+ 3 files changed, 37 insertions(+), 28 deletions(-)
+
+--- a/profiles/input/hog.c
++++ b/profiles/input/hog.c
+@@ -69,24 +69,6 @@
+ static gboolean suspend_supported = FALSE;
+ static struct queue *devices = NULL;
+ 
+-static void attio_connected_cb(GAttrib *attrib, gpointer user_data)
+-{
+-	struct hog_device *dev = user_data;
+-
+-	DBG("HoG connected");
+-
+-	bt_hog_attach(dev->hog, attrib);
+-}
+-
+-static void attio_disconnected_cb(gpointer user_data)
+-{
+-	struct hog_device *dev = user_data;
+-
+-	DBG("HoG disconnected");
+-
+-	bt_hog_detach(dev->hog);
+-}
+-
+ static struct hog_device *hog_device_new(struct btd_device *device,
+ 						struct gatt_primary *prim)
+ {
+@@ -115,15 +97,6 @@
+ 
+ 	dev->device = btd_device_ref(device);
+ 
+-	/*
+-	 * TODO: Remove attio callback and use .accept once using
+-	 * bt_gatt_client.
+-	 */
+-	dev->attioid = btd_device_add_attio_callback(device,
+-							attio_connected_cb,
+-							attio_disconnected_cb,
+-							dev);
+-
+ 	if (!devices)
+ 		devices = queue_new();
+ 
+@@ -142,7 +115,6 @@
+ 		devices = NULL;
+ 	}
+ 
+-	btd_device_remove_attio_callback(dev->device, dev->attioid);
+ 	btd_device_unref(dev->device);
+ 	bt_hog_unref(dev->hog);
+ 	free(dev);
+@@ -215,11 +187,39 @@
+ 	hog_device_free(dev);
+ }
+ 
++static int hog_accept(struct btd_service *service)
++{
++	struct hog_device *dev = btd_service_get_user_data(service);
++	struct btd_device *device = btd_service_get_device(service);
++	GAttrib *attrib = btd_device_get_attrib(device);
++
++	/* TODO: Replace GAttrib with bt_gatt_client */
++	bt_hog_attach(dev->hog, attrib);
++
++	btd_service_connecting_complete(service, 0);
++
++	return 0;
++}
++
++static int hog_disconnect(struct btd_service *service)
++{
++	struct hog_device *dev = btd_service_get_user_data(service);
++
++	bt_hog_detach(dev->hog);
++
++	btd_service_disconnecting_complete(service, 0);
++
++	return 0;
++}
++
+ static struct btd_profile hog_profile = {
+ 	.name		= "input-hog",
+ 	.remote_uuid	= HOG_UUID,
+ 	.device_probe	= hog_probe,
+ 	.device_remove	= hog_remove,
++	.accept		= hog_accept,
++	.disconnect	= hog_disconnect,
++	.auto_connect	= true,
+ };
+ 
+ static int hog_init(void)
+--- a/src/device.c
++++ b/src/device.c
+@@ -5899,6 +5899,14 @@
+ 	return device->client;
+ }
+ 
++void *btd_device_get_attrib(struct btd_device *device)
++{
++	if (!device)
++		return NULL;
++
++	return device->attrib;
++}
++
+ struct bt_gatt_server *btd_device_get_gatt_server(struct btd_device *device)
+ {
+ 	if (!device)
+--- a/src/device.h
++++ b/src/device.h
+@@ -70,6 +70,7 @@
+ struct gatt_db *btd_device_get_gatt_db(struct btd_device *device);
+ struct bt_gatt_client *btd_device_get_gatt_client(struct btd_device *device);
+ struct bt_gatt_server *btd_device_get_gatt_server(struct btd_device *device);
++void *btd_device_get_attrib(struct btd_device *device);
+ void btd_device_gatt_set_service_changed(struct btd_device *device,
+ 						uint16_t start, uint16_t end);
+ bool device_attach_att(struct btd_device *dev, GIOChannel *io);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -17,4 +17,12 @@ migrate_scripts_python3.patch
 
 # Secirity fix(es)
 CVE-2017-1000250.patch
+CVE-2016-7837.patch
+CVE-2020-0556-pre1.patch
+CVE-2020-0556-1.patch
+CVE-2020-0556-2.patch
+CVE-2020-0556-3.patch
+CVE-2020-0556-4.patch
+
+# UBports-specific patch
 broadcom-firmware.patch

--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
 http://www.kernel.org/pub/linux/bluetooth/bluez-5.41.tar.xz
-bluez_5.42+ubports3.orig.tar.xz
+bluez_5.42+ubports4.orig.tar.xz


### PR DESCRIPTION
  * SECURITY UPDATE: buffer overflow in parse_line function
    - debian/patches/CVE-2016-7837.patch: make sure we don't write past the
      end of the array in tools/csr.c.
    - CVE-2016-7837
  * SECURITY UPDATE: privilege escalation via improper access control
    - debian/patches/CVE-2020-0556-pre1.patch: use .accept and .disconnect
      instead of attio in profiles/input/hog.c, src/device.c, src/device.h.
    - debian/patches/CVE-2020-0556-1.patch: HOGP must only accept data from
      bonded devices in profiles/input/hog.c.
    - debian/patches/CVE-2020-0556-2.patch: HID accepts bonded device
      connections only in profiles/input/device.c, profiles/input/device.h,
      profiles/input/input.conf, profiles/input/manager.c.
    - debian/patches/CVE-2020-0556-3.patch: attempt to set security level
      if not bonded in profiles/input/hog.c.
    - debian/patches/CVE-2020-0556-4.patch: add LEAutoSecurity setting to
      input.conf in profiles/input/device.h, profiles/input/hog.c,
      profiles/input/input.conf, profiles/input/manager.c.
    - CVE-2020-0556

I would like this PR to be included in OTA-12, if possible.