### PR TITLE
Fake the success of D-Bus activation

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+bluez (5.42+ubports5) xenial; urgency=medium
+
+  * Fake the success of D-Bus activation, so that oFono HFP profile
+    registration works properly.
+    - d/patches/fake-dbus-activation.patch
+
+ -- Ratchanan Srirattanamet <ratchanan@ubports.com>  Fri, 24 Apr 2020 02:54:51 +0700
+
 bluez (5.42+ubports4) xenial; urgency=medium
 
   * SECURITY UPDATE: buffer overflow in parse_line function

--- a/debian/patches/fake-dbus-activation.patch
+++ b/debian/patches/fake-dbus-activation.patch
@@ -1,0 +1,25 @@
+Description: Fake the success of D-Bus activation
+ oFono races with bluetoothd startup to register HFP profile. Normally,
+ this would trigger D-Bus activation. However, D-Bus activation does not
+ work properly on non-systemd system, and, in Ubuntu Touch, we needs the
+ proper startup sequence to initialize Bluetooth properly.
+ .
+ We don't want HFP profile registration to fail, because that means
+ we'll fallback to HSP profile in PulseAudio with less capability. Thus,
+ the solution is to fake the activation success to D-Bus, then wait for
+ bluetoothd to be started by Upstart. This works because D-Bus waits for
+ quite some times after it successfuly activate a service.
+Author: Ratchanan Srirattanamet <ratchanan@ubports.com>
+Forwarded: not-needed
+Last-Update: 2020-04-24
+---
+This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
+--- a/src/org.bluez.service
++++ b/src/org.bluez.service
+@@ -1,5 +1,5 @@
+ [D-BUS Service]
+ Name=org.bluez
+-Exec=/bin/false
++Exec=/bin/true
+ User=root
+ SystemdService=dbus-org.bluez.service

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -26,3 +26,4 @@ CVE-2020-0556-4.patch
 
 # UBports-specific patch
 broadcom-firmware.patch
+fake-dbus-activation.patch

--- a/ubports.source_location
+++ b/ubports.source_location
@@ -1,2 +1,2 @@
 http://www.kernel.org/pub/linux/bluetooth/bluez-5.41.tar.xz
-bluez_5.42+ubports4.orig.tar.xz
+bluez_5.42+ubports5.orig.tar.xz


### PR DESCRIPTION
oFono races with bluetoothd startup to register HFP profile. Normally,
this would trigger D-Bus activation. However, D-Bus activation does not
work properly on non-systemd system, and, in Ubuntu Touch, we needs the
proper startup sequence to initialize Bluetooth properly.

We don't want HFP profile registration to fail, because that means
we'll fallback to HSP profile in PulseAudio with less capability. Thus,
the solution is to fake the activation success to D-Bus, then wait for
bluetoothd to be started by Upstart. This works because D-Bus waits for
quite some times after it successfuly activate a service.

For QA: make a call using a Bluetooth headset. See if a hangup button works correctly.