### PR TITLE
Do not try to autopair with Nissan Connect devices

### DIFF
--- a/debian/patches/device-fixes-nissan-connect.patch
+++ b/debian/patches/device-fixes-nissan-connect.patch
@@ -1,0 +1,13 @@
+--- a/plugins/autopair.c
++++ b/plugins/autopair.c
+@@ -78,6 +78,10 @@
+ 	if (name != NULL && strstr(name, "iCade") != NULL)
+ 		return 0;
+ 
++	/* Nissan Connect carkits use PIN 1234 but refuse a retry */
++	if (name != NULL && strstr(name, "NISSAN CONNECT") != NULL)
++		return 0;
++
+ 	/* This is a class-based pincode guesser. Ignore devices with an
+ 	 * unknown class.
+ 	 */

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -20,3 +20,4 @@ CVE-2020-0556-4.patch
 # UBports-specific patch
 broadcom-firmware.patch
 fake-dbus-activation.patch
+device-fixes-nissan-connect.patch


### PR DESCRIPTION
It seems that Nissan Connect devices a) do not use 0000 but 1234 as default code, but also b) the autopair plugin is not able to make a second attempt to pair, as the carkit just bails out and cancels pairing on the first wrong code. Let´s try to not use the autopairing at all for those devices.
